### PR TITLE
[codex] Sort repos by actual last update

### DIFF
--- a/src/components/Repos.vue
+++ b/src/components/Repos.vue
@@ -16,7 +16,7 @@
     <v-data-table
       :headers="headers"
       :items="items"
-      :sort-by="['lastUpdate']"
+      :sort-by="['lastUpdateSortValue']"
       :sort-desc="[true]"
       :items-per-page="100"
       :search="search"
@@ -44,6 +44,15 @@
 <script>
 import repos from "../assets/repos.json";
 
+function normalizeRepos(items) {
+  return items
+    .map(item => ({
+      ...item,
+      lastUpdateSortValue: Date.parse(item.lastUpdate) || 0
+    }))
+    .sort((left, right) => right.lastUpdateSortValue - left.lastUpdateSortValue);
+}
+
 export default {
   data() {
     return {
@@ -54,9 +63,9 @@ export default {
         { text: "Stars", value: "stars" },
         { text: "Forks", value: "forks" },
         { text: "LastTag", value: "lastTag" },
-        { text: "LastUpdate", value: "lastUpdate" }
+        { text: "LastUpdate", value: "lastUpdateSortValue" }
       ],
-      items: repos
+      items: normalizeRepos(repos)
     };
   },
   methods: {


### PR DESCRIPTION
## What changed

This updates the repos table to sort by a parsed timestamp instead of the `lastUpdate` display string.

## Why

`v-data-table` was sorting the rendered `lastUpdate` values lexicographically, which can misorder repos when the field is treated as text instead of a real date.

## Impact

The default table order and `LastUpdate` column sorting now follow actual recency.

## Root cause

The component passed the raw `lastUpdate` field directly into the table sort configuration, so ordering depended on string comparison.

## Validation

- Installed project dependencies with `yarn install`
- `yarn run build` failed first with a Node/OpenSSL compatibility issue from the legacy Vue CLI/Webpack stack
- `NODE_OPTIONS=--openssl-legacy-provider yarn run build` then failed because the existing project dependency setup does not resolve `vue` cleanly during build

## Notes

- The local `src/assets/repos.json` backfill used for manual verification remains gitignored and is not included in this PR.