### PR TITLE
Fix upstream README badge parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: yarn install --immutable
+      - name: Test metadata parser
+        run: node --test scripts/sync-repos-metadata.test.js
       - name: Sync repos metadata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/sync-repos-metadata.js
+++ b/scripts/sync-repos-metadata.js
@@ -243,7 +243,7 @@ function parseReadmeEntries(readmeText) {
 
   bullets.forEach(function(bullet) {
     const match = bullet.match(
-      /^-\s+\[(.+?)\]\s*\((https?:\/\/[^)]+)\)(?:\s+\[[^\]]*])?\s*-\s*(.+)$/
+      /^-\s+\[(.+?)\]\s*\((https?:\/\/[^)]+)\)(?:\s+(?:\[[^\]]*]|<sub>.*?<\/sub>))*\s*-\s*(.+)$/
     );
 
     if (!match) {
@@ -414,7 +414,13 @@ async function main() {
   console.log("Wrote " + items.length + " repos to " + options.outputPath);
 }
 
-main().catch(function(error) {
-  console.error(error.stack || error.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(function(error) {
+    console.error(error.stack || error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  parseReadmeEntries: parseReadmeEntries
+};

--- a/scripts/sync-repos-metadata.test.js
+++ b/scripts/sync-repos-metadata.test.js
@@ -1,0 +1,34 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { parseReadmeEntries } = require("./sync-repos-metadata");
+
+test("parses legacy and badge-based GitHub entries", function() {
+  const readme = [
+    "- [Legacy](https://github.com/example/legacy) [Java] - Legacy description.",
+    "- [Current](https://github.com/example/current) <sub>![Rust][language-rust]</sub> - Current description.",
+    "- [Archived](https://github.com/example/archived) <sub>![Archived][archived-badge]</sub> <sub>![Java/C][language-java-c]</sub> - Archived description.",
+    "- [Website](https://example.com/project) <sub>![Go][language-go]</sub> - Not a GitHub repository."
+  ].join("\n");
+
+  assert.deepEqual(parseReadmeEntries(readme), [
+    {
+      name: "Legacy",
+      link: "https://github.com/example/legacy",
+      description: "Legacy description.",
+      repoRef: { owner: "example", repo: "legacy" }
+    },
+    {
+      name: "Current",
+      link: "https://github.com/example/current",
+      description: "Current description.",
+      repoRef: { owner: "example", repo: "current" }
+    },
+    {
+      name: "Archived",
+      link: "https://github.com/example/archived",
+      description: "Archived description.",
+      repoRef: { owner: "example", repo: "archived" }
+    }
+  ]);
+});


### PR DESCRIPTION
## Summary
- accept the upstream README's current `<sub>...</sub>` language and archived badge markup
- preserve support for legacy `[Language]` metadata entries
- add focused parser regression coverage and run it in CI before metadata synchronization

## Root cause

`manuzhang/awesome-streaming#98` replaced the old `[Language]` suffixes with rendered `<sub>` badge markup. The downstream metadata parser only accepted the old syntax, so scheduled CI parsed zero repositories and stopped before the build and deploy steps.

## Impact

The daily metadata sync can consume the current upstream README again while remaining compatible with legacy entries.

## Validation
- `node --test scripts/sync-repos-metadata.test.js`
- live metadata sync against current `manuzhang/awesome-streaming` master: 122 repositories synced
- `yarn run lint`
- `NODE_OPTIONS=--openssl-legacy-provider yarn run build`
- `git diff --check`