### PR TITLE
Separate active and archived projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
         run: yarn install --immutable
       - name: Test metadata parser
         run: node --test scripts/sync-repos-metadata.test.js
+      - name: Restore repos metadata
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: src/assets/repos.json
+          key: repos-metadata-${{ github.run_id }}
+          restore-keys: |
+            repos-metadata-
       - name: Sync repos metadata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,6 +42,12 @@ jobs:
         env:
           NODE_OPTIONS: --openssl-legacy-provider
         run: yarn run build
+      - name: Save repos metadata
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/save@v4
+        with:
+          path: src/assets/repos.json
+          key: repos-metadata-${{ github.run_id }}
       - name: Deploy
         if: github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Website for [awesome-streaming](https://github.com/manuzhang/awesome-streaming) projects with up-to-date metadata (stars, forks, lastUpdate time, etc).
 
-The metadata is fetched daily by syncing the upstream README and enriching GitHub repository entries through the GitHub REST API in [scripts/sync-repos-metadata.js](./scripts/sync-repos-metadata.js).
+The metadata is fetched daily by syncing the upstream README and enriching active GitHub repository entries through the GitHub REST API in [scripts/sync-repos-metadata.js](./scripts/sync-repos-metadata.js). Archived entries retain their last known metadata without additional GitHub API requests.
 
 This project is built with [vue-cli](https://cli.vuejs.org/), [vuetify](https://vuetifyjs.com) and [github-corners](http://tholman.com/github-corners/), and published to [GitHub pages](https://docs.travis-ci.com/user/deployment/pages/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Website for [awesome-streaming](https://github.com/manuzhang/awesome-streaming) projects with up-to-date metadata (stars, forks, lastUpdate time, etc).
 
-The metadata is fetched daily by syncing the upstream README and enriching active GitHub repository entries through the GitHub REST API in [scripts/sync-repos-metadata.js](./scripts/sync-repos-metadata.js). After initial enrichment, archived entries retain their last known metadata without additional GitHub API requests.
+The metadata is fetched daily by syncing the upstream README and enriching active GitHub repository entries through the GitHub REST API in [scripts/sync-repos-metadata.js](./scripts/sync-repos-metadata.js). After initial enrichment, archived entries retain their last known metadata without additional GitHub API requests. Non-PR CI runs cache the generated metadata between refreshes.
 
 This project is built with [vue-cli](https://cli.vuejs.org/), [vuetify](https://vuetifyjs.com) and [github-corners](http://tholman.com/github-corners/), and published to [GitHub pages](https://docs.travis-ci.com/user/deployment/pages/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Website for [awesome-streaming](https://github.com/manuzhang/awesome-streaming) projects with up-to-date metadata (stars, forks, lastUpdate time, etc).
 
-The metadata is fetched daily by syncing the upstream README and enriching active GitHub repository entries through the GitHub REST API in [scripts/sync-repos-metadata.js](./scripts/sync-repos-metadata.js). Archived entries retain their last known metadata without additional GitHub API requests.
+The metadata is fetched daily by syncing the upstream README and enriching active GitHub repository entries through the GitHub REST API in [scripts/sync-repos-metadata.js](./scripts/sync-repos-metadata.js). After initial enrichment, archived entries retain their last known metadata without additional GitHub API requests.
 
 This project is built with [vue-cli](https://cli.vuejs.org/), [vuetify](https://vuetifyjs.com) and [github-corners](http://tholman.com/github-corners/), and published to [GitHub pages](https://docs.travis-ci.com/user/deployment/pages/)
 

--- a/scripts/sync-repos-metadata.js
+++ b/scripts/sync-repos-metadata.js
@@ -276,27 +276,24 @@ function hasStoredMetadata(item) {
     item.forks !== null &&
     item.forks !== undefined &&
     item.lastUpdate !== null &&
-    item.lastUpdate !== undefined
+    item.lastUpdate !== undefined &&
+    (item.releaseLookupSucceeded === true ||
+      (item.releaseLookupSucceeded === undefined && item.lastTag != null))
   );
+}
+
+function reusePreviousItem(entry, previousItem) {
+  return Object.assign({}, previousItem, {
+    name: entry.name,
+    link: entry.link,
+    description: entry.description,
+    isArchived: entry.isArchived
+  });
 }
 
 async function buildRepoItem(entry, previousItem, fetchMetadata, token) {
   if (entry.isArchived && hasStoredMetadata(previousItem)) {
-    return Object.assign(
-      {
-        stars: null,
-        forks: null,
-        lastTag: null,
-        lastUpdate: null
-      },
-      previousItem || {},
-      {
-        name: entry.name,
-        link: entry.link,
-        description: entry.description,
-        isArchived: true
-      }
-    );
+    return reusePreviousItem(entry, previousItem);
   }
 
   const metadata = await fetchMetadata(entry.repoRef, token);
@@ -308,6 +305,7 @@ async function buildRepoItem(entry, previousItem, fetchMetadata, token) {
     forks: metadata.forks,
     lastTag: metadata.lastTag || (previousItem && previousItem.lastTag) || null,
     lastUpdate: metadata.lastUpdate,
+    releaseLookupSucceeded: metadata.releaseLookupSucceeded,
     isArchived: entry.isArchived
   };
 }
@@ -325,6 +323,7 @@ async function fetchRepoMetadata(repoRef, token) {
     "/releases?per_page=1";
 
   let lastTag = null;
+  let releaseLookupSucceeded = true;
   try {
     const releases = await requestJsonWithRetry(releasesUrl, token, 2);
     if (
@@ -336,6 +335,7 @@ async function fetchRepoMetadata(repoRef, token) {
       lastTag = releases[0].tag_name;
     }
   } catch (error) {
+    releaseLookupSucceeded = false;
     console.warn(
       "Unable to fetch releases for " +
         repoRef.owner +
@@ -351,6 +351,7 @@ async function fetchRepoMetadata(repoRef, token) {
     forks: payload.forks_count,
     lastTag: lastTag,
     lastUpdate: payload.pushed_at,
+    releaseLookupSucceeded: releaseLookupSucceeded,
     isArchived: payload.archived
   };
 }
@@ -450,11 +451,7 @@ async function main() {
         );
       } catch (error) {
         if (previousItem) {
-          items[task.index] = Object.assign({}, previousItem, {
-            name: entry.name,
-            link: entry.link,
-            description: entry.description
-          });
+          items[task.index] = reusePreviousItem(entry, previousItem);
           console.warn("Fell back to existing metadata for " + entry.name + ": " + error.message);
           return;
         }
@@ -486,5 +483,6 @@ if (require.main === module) {
 
 module.exports = {
   buildRepoItem: buildRepoItem,
-  parseReadmeEntries: parseReadmeEntries
+  parseReadmeEntries: parseReadmeEntries,
+  reusePreviousItem: reusePreviousItem
 };

--- a/scripts/sync-repos-metadata.js
+++ b/scripts/sync-repos-metadata.js
@@ -260,11 +260,44 @@ function parseReadmeEntries(readmeText) {
       name: match[1].trim(),
       link: link,
       description: match[3].trim(),
-      repoRef: repoRef
+      repoRef: repoRef,
+      isArchived: /!\[Archived\]\[archived-badge\]/i.test(bullet)
     });
   });
 
   return entries;
+}
+
+async function buildRepoItem(entry, previousItem, fetchMetadata, token) {
+  if (entry.isArchived) {
+    return Object.assign(
+      {
+        stars: null,
+        forks: null,
+        lastTag: null,
+        lastUpdate: null
+      },
+      previousItem || {},
+      {
+        name: entry.name,
+        link: entry.link,
+        description: entry.description,
+        isArchived: true
+      }
+    );
+  }
+
+  const metadata = await fetchMetadata(entry.repoRef, token);
+  return {
+    name: entry.name,
+    link: entry.link,
+    description: entry.description,
+    stars: metadata.stars,
+    forks: metadata.forks,
+    lastTag: metadata.lastTag || (previousItem && previousItem.lastTag) || null,
+    lastUpdate: metadata.lastUpdate,
+    isArchived: metadata.isArchived
+  };
 }
 
 async function fetchRepoMetadata(repoRef, token) {
@@ -364,8 +397,17 @@ async function main() {
     };
   });
   const failures = [];
+  const archivedCount = entries.filter(function(entry) {
+    return entry.isArchived;
+  }).length;
 
-  console.log("Syncing metadata for " + entries.length + " repos");
+  console.log(
+    "Syncing metadata for " +
+      (entries.length - archivedCount) +
+      " active repos; reusing " +
+      archivedCount +
+      " archived repos"
+  );
 
   await createWorkQueue(
     tasks,
@@ -373,18 +415,13 @@ async function main() {
       const entry = task.entry;
       const previousItem = existingByRepoKey.get(repoKey(entry.repoRef)) || null;
       try {
-        const metadata = await fetchRepoMetadata(entry.repoRef, token);
-        items[task.index] = {
-          name: entry.name,
-          link: entry.link,
-          description: entry.description,
-          stars: metadata.stars,
-          forks: metadata.forks,
-          lastTag: metadata.lastTag || (previousItem && previousItem.lastTag) || null,
-          lastUpdate: metadata.lastUpdate,
-          isArchived: metadata.isArchived
-        };
-        console.log("Synced " + entry.name);
+        items[task.index] = await buildRepoItem(
+          entry,
+          previousItem,
+          fetchRepoMetadata,
+          token
+        );
+        console.log((entry.isArchived ? "Reused archived metadata for " : "Synced ") + entry.name);
       } catch (error) {
         if (previousItem) {
           items[task.index] = Object.assign({}, previousItem, {
@@ -422,5 +459,6 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildRepoItem: buildRepoItem,
   parseReadmeEntries: parseReadmeEntries
 };

--- a/scripts/sync-repos-metadata.js
+++ b/scripts/sync-repos-metadata.js
@@ -275,8 +275,8 @@ function hasStoredMetadata(item) {
     item.stars !== undefined &&
     item.forks !== null &&
     item.forks !== undefined &&
-    item.lastUpdate !== null &&
-    item.lastUpdate !== undefined &&
+    (item.repositoryLookupSucceeded === true ||
+      (item.repositoryLookupSucceeded === undefined && item.lastUpdate != null)) &&
     (item.releaseLookupSucceeded === true ||
       (item.releaseLookupSucceeded === undefined && item.lastTag != null))
   );
@@ -305,6 +305,7 @@ async function buildRepoItem(entry, previousItem, fetchMetadata, token) {
     forks: metadata.forks,
     lastTag: metadata.lastTag || (previousItem && previousItem.lastTag) || null,
     lastUpdate: metadata.lastUpdate,
+    repositoryLookupSucceeded: metadata.repositoryLookupSucceeded,
     releaseLookupSucceeded: metadata.releaseLookupSucceeded,
     isArchived: entry.isArchived
   };
@@ -351,6 +352,7 @@ async function fetchRepoMetadata(repoRef, token) {
     forks: payload.forks_count,
     lastTag: lastTag,
     lastUpdate: payload.pushed_at,
+    repositoryLookupSucceeded: true,
     releaseLookupSucceeded: releaseLookupSucceeded,
     isArchived: payload.archived
   };

--- a/scripts/sync-repos-metadata.js
+++ b/scripts/sync-repos-metadata.js
@@ -268,8 +268,20 @@ function parseReadmeEntries(readmeText) {
   return entries;
 }
 
+function hasStoredMetadata(item) {
+  return (
+    item &&
+    item.stars !== null &&
+    item.stars !== undefined &&
+    item.forks !== null &&
+    item.forks !== undefined &&
+    item.lastUpdate !== null &&
+    item.lastUpdate !== undefined
+  );
+}
+
 async function buildRepoItem(entry, previousItem, fetchMetadata, token) {
-  if (entry.isArchived) {
+  if (entry.isArchived && hasStoredMetadata(previousItem)) {
     return Object.assign(
       {
         stars: null,
@@ -296,7 +308,7 @@ async function buildRepoItem(entry, previousItem, fetchMetadata, token) {
     forks: metadata.forks,
     lastTag: metadata.lastTag || (previousItem && previousItem.lastTag) || null,
     lastUpdate: metadata.lastUpdate,
-    isArchived: metadata.isArchived
+    isArchived: entry.isArchived
   };
 }
 
@@ -400,12 +412,22 @@ async function main() {
   const archivedCount = entries.filter(function(entry) {
     return entry.isArchived;
   }).length;
+  const archivedToSyncCount = entries.filter(function(entry) {
+    if (!entry.isArchived) {
+      return false;
+    }
+
+    const previousItem = existingByRepoKey.get(repoKey(entry.repoRef)) || null;
+    return !hasStoredMetadata(previousItem);
+  }).length;
 
   console.log(
     "Syncing metadata for " +
       (entries.length - archivedCount) +
-      " active repos; reusing " +
-      archivedCount +
+      " active repos and " +
+      archivedToSyncCount +
+      " archived repos; reusing " +
+      (archivedCount - archivedToSyncCount) +
       " archived repos"
   );
 
@@ -421,7 +443,11 @@ async function main() {
           fetchRepoMetadata,
           token
         );
-        console.log((entry.isArchived ? "Reused archived metadata for " : "Synced ") + entry.name);
+        console.log(
+          (entry.isArchived && hasStoredMetadata(previousItem)
+            ? "Reused archived metadata for "
+            : "Synced ") + entry.name
+        );
       } catch (error) {
         if (previousItem) {
           items[task.index] = Object.assign({}, previousItem, {

--- a/scripts/sync-repos-metadata.test.js
+++ b/scripts/sync-repos-metadata.test.js
@@ -95,6 +95,7 @@ test("fetches metadata once for an unseen archived entry", async function() {
       forks: 4,
       lastTag: "v2.0.0",
       lastUpdate: "2025-01-01T00:00:00Z",
+      repositoryLookupSucceeded: true,
       releaseLookupSucceeded: true,
       isArchived: false
     };
@@ -109,6 +110,7 @@ test("fetches metadata once for an unseen archived entry", async function() {
     forks: 4,
     lastTag: "v2.0.0",
     lastUpdate: "2025-01-01T00:00:00Z",
+    repositoryLookupSucceeded: true,
     releaseLookupSucceeded: true,
     isArchived: true
   });
@@ -141,6 +143,7 @@ test("refreshes an archived entry when stored metadata is incomplete", async fun
       forks: 4,
       lastTag: null,
       lastUpdate: "2025-01-01T00:00:00Z",
+      repositoryLookupSucceeded: true,
       releaseLookupSucceeded: true,
       isArchived: true
     };
@@ -165,6 +168,7 @@ test("uses the README archive status for active entries", async function() {
       forks: 6,
       lastTag: "v3.0.0",
       lastUpdate: "2026-01-01T00:00:00Z",
+      repositoryLookupSucceeded: true,
       releaseLookupSucceeded: true,
       isArchived: true
     };
@@ -190,6 +194,7 @@ test("retries a failed archived release lookup", async function() {
       forks: 4,
       lastTag: null,
       lastUpdate: "2025-01-01T00:00:00Z",
+      repositoryLookupSucceeded: true,
       releaseLookupSucceeded: false,
       isArchived: true
     };
@@ -201,6 +206,7 @@ test("retries a failed archived release lookup", async function() {
       forks: 4,
       lastTag: null,
       lastUpdate: "2025-01-01T00:00:00Z",
+      repositoryLookupSucceeded: true,
       releaseLookupSucceeded: true,
       isArchived: true
     };
@@ -211,6 +217,38 @@ test("retries a failed archived release lookup", async function() {
   });
 
   assert.equal(fetchCount, 2);
+});
+
+test("reuses an archived entry with a valid null push timestamp", async function() {
+  const entry = {
+    name: "Empty archived project",
+    link: "https://github.com/example/empty-archived",
+    description: "Archived repository without commits.",
+    repoRef: { owner: "example", repo: "empty-archived" },
+    isArchived: true
+  };
+  let fetchCount = 0;
+
+  const completeItem = await buildRepoItem(entry, null, async function() {
+    fetchCount += 1;
+    return {
+      stars: 0,
+      forks: 0,
+      lastTag: null,
+      lastUpdate: null,
+      repositoryLookupSucceeded: true,
+      releaseLookupSucceeded: true,
+      isArchived: true
+    };
+  });
+  const reusedItem = await buildRepoItem(entry, completeItem, async function() {
+    fetchCount += 1;
+    throw new Error("Successful null push timestamp should be reused");
+  });
+
+  assert.equal(fetchCount, 1);
+  assert.equal(reusedItem.lastUpdate, null);
+  assert.equal(reusedItem.repositoryLookupSucceeded, true);
 });
 
 test("applies the README archive status when reusing metadata after a failure", function() {

--- a/scripts/sync-repos-metadata.test.js
+++ b/scripts/sync-repos-metadata.test.js
@@ -1,7 +1,11 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-const { buildRepoItem, parseReadmeEntries } = require("./sync-repos-metadata");
+const {
+  buildRepoItem,
+  parseReadmeEntries,
+  reusePreviousItem
+} = require("./sync-repos-metadata");
 
 test("parses legacy and badge-based GitHub entries", function() {
   const readme = [
@@ -91,6 +95,7 @@ test("fetches metadata once for an unseen archived entry", async function() {
       forks: 4,
       lastTag: "v2.0.0",
       lastUpdate: "2025-01-01T00:00:00Z",
+      releaseLookupSucceeded: true,
       isArchived: false
     };
   });
@@ -104,6 +109,7 @@ test("fetches metadata once for an unseen archived entry", async function() {
     forks: 4,
     lastTag: "v2.0.0",
     lastUpdate: "2025-01-01T00:00:00Z",
+    releaseLookupSucceeded: true,
     isArchived: true
   });
 });
@@ -135,6 +141,7 @@ test("refreshes an archived entry when stored metadata is incomplete", async fun
       forks: 4,
       lastTag: null,
       lastUpdate: "2025-01-01T00:00:00Z",
+      releaseLookupSucceeded: true,
       isArchived: true
     };
   });
@@ -158,9 +165,72 @@ test("uses the README archive status for active entries", async function() {
       forks: 6,
       lastTag: "v3.0.0",
       lastUpdate: "2026-01-01T00:00:00Z",
+      releaseLookupSucceeded: true,
       isArchived: true
     };
   });
 
   assert.equal(item.isArchived, false);
+});
+
+test("retries a failed archived release lookup", async function() {
+  const entry = {
+    name: "Archived project",
+    link: "https://github.com/example/archived",
+    description: "Archived description.",
+    repoRef: { owner: "example", repo: "archived" },
+    isArchived: true
+  };
+  let fetchCount = 0;
+
+  const failedItem = await buildRepoItem(entry, null, async function() {
+    fetchCount += 1;
+    return {
+      stars: 20,
+      forks: 4,
+      lastTag: null,
+      lastUpdate: "2025-01-01T00:00:00Z",
+      releaseLookupSucceeded: false,
+      isArchived: true
+    };
+  });
+  const completeItem = await buildRepoItem(entry, failedItem, async function() {
+    fetchCount += 1;
+    return {
+      stars: 20,
+      forks: 4,
+      lastTag: null,
+      lastUpdate: "2025-01-01T00:00:00Z",
+      releaseLookupSucceeded: true,
+      isArchived: true
+    };
+  });
+  await buildRepoItem(entry, completeItem, async function() {
+    fetchCount += 1;
+    throw new Error("Successful empty release lookup should be reused");
+  });
+
+  assert.equal(fetchCount, 2);
+});
+
+test("applies the README archive status when reusing metadata after a failure", function() {
+  const entry = {
+    name: "Active project",
+    link: "https://github.com/example/project",
+    description: "Active description.",
+    isArchived: false
+  };
+  const previousItem = {
+    name: "Archived project",
+    link: entry.link,
+    description: "Archived description.",
+    stars: 20,
+    forks: 4,
+    lastTag: "v2.0.0",
+    lastUpdate: "2025-01-01T00:00:00Z",
+    releaseLookupSucceeded: true,
+    isArchived: true
+  };
+
+  assert.equal(reusePreviousItem(entry, previousItem).isArchived, false);
 });

--- a/scripts/sync-repos-metadata.test.js
+++ b/scripts/sync-repos-metadata.test.js
@@ -1,7 +1,7 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-const { parseReadmeEntries } = require("./sync-repos-metadata");
+const { buildRepoItem, parseReadmeEntries } = require("./sync-repos-metadata");
 
 test("parses legacy and badge-based GitHub entries", function() {
   const readme = [
@@ -16,19 +16,60 @@ test("parses legacy and badge-based GitHub entries", function() {
       name: "Legacy",
       link: "https://github.com/example/legacy",
       description: "Legacy description.",
-      repoRef: { owner: "example", repo: "legacy" }
+      repoRef: { owner: "example", repo: "legacy" },
+      isArchived: false
     },
     {
       name: "Current",
       link: "https://github.com/example/current",
       description: "Current description.",
-      repoRef: { owner: "example", repo: "current" }
+      repoRef: { owner: "example", repo: "current" },
+      isArchived: false
     },
     {
       name: "Archived",
       link: "https://github.com/example/archived",
       description: "Archived description.",
-      repoRef: { owner: "example", repo: "archived" }
+      repoRef: { owner: "example", repo: "archived" },
+      isArchived: true
     }
   ]);
+});
+
+test("reuses archived metadata without fetching GitHub", async function() {
+  const entry = {
+    name: "Archived project",
+    link: "https://github.com/example/archived",
+    description: "Updated description.",
+    repoRef: { owner: "example", repo: "archived" },
+    isArchived: true
+  };
+  const previousItem = {
+    name: "Old name",
+    link: entry.link,
+    description: "Old description.",
+    stars: 10,
+    forks: 2,
+    lastTag: "v1.0.0",
+    lastUpdate: "2024-01-01T00:00:00Z",
+    isArchived: false
+  };
+  let fetchCount = 0;
+
+  const item = await buildRepoItem(entry, previousItem, async function() {
+    fetchCount += 1;
+    throw new Error("Archived metadata should not be fetched");
+  });
+
+  assert.equal(fetchCount, 0);
+  assert.deepEqual(item, {
+    name: "Archived project",
+    link: entry.link,
+    description: "Updated description.",
+    stars: 10,
+    forks: 2,
+    lastTag: "v1.0.0",
+    lastUpdate: "2024-01-01T00:00:00Z",
+    isArchived: true
+  });
 });

--- a/scripts/sync-repos-metadata.test.js
+++ b/scripts/sync-repos-metadata.test.js
@@ -73,3 +73,94 @@ test("reuses archived metadata without fetching GitHub", async function() {
     isArchived: true
   });
 });
+
+test("fetches metadata once for an unseen archived entry", async function() {
+  const entry = {
+    name: "New archived project",
+    link: "https://github.com/example/new-archived",
+    description: "Archived description.",
+    repoRef: { owner: "example", repo: "new-archived" },
+    isArchived: true
+  };
+  let fetchCount = 0;
+
+  const item = await buildRepoItem(entry, null, async function() {
+    fetchCount += 1;
+    return {
+      stars: 20,
+      forks: 4,
+      lastTag: "v2.0.0",
+      lastUpdate: "2025-01-01T00:00:00Z",
+      isArchived: false
+    };
+  });
+
+  assert.equal(fetchCount, 1);
+  assert.deepEqual(item, {
+    name: entry.name,
+    link: entry.link,
+    description: entry.description,
+    stars: 20,
+    forks: 4,
+    lastTag: "v2.0.0",
+    lastUpdate: "2025-01-01T00:00:00Z",
+    isArchived: true
+  });
+});
+
+test("refreshes an archived entry when stored metadata is incomplete", async function() {
+  const entry = {
+    name: "Archived project",
+    link: "https://github.com/example/archived",
+    description: "Archived description.",
+    repoRef: { owner: "example", repo: "archived" },
+    isArchived: true
+  };
+  const previousItem = {
+    name: entry.name,
+    link: entry.link,
+    description: entry.description,
+    stars: null,
+    forks: null,
+    lastTag: null,
+    lastUpdate: null,
+    isArchived: true
+  };
+  let fetchCount = 0;
+
+  const item = await buildRepoItem(entry, previousItem, async function() {
+    fetchCount += 1;
+    return {
+      stars: 20,
+      forks: 4,
+      lastTag: null,
+      lastUpdate: "2025-01-01T00:00:00Z",
+      isArchived: true
+    };
+  });
+
+  assert.equal(fetchCount, 1);
+  assert.equal(item.lastUpdate, "2025-01-01T00:00:00Z");
+});
+
+test("uses the README archive status for active entries", async function() {
+  const entry = {
+    name: "Active project",
+    link: "https://github.com/example/active",
+    description: "Active description.",
+    repoRef: { owner: "example", repo: "active" },
+    isArchived: false
+  };
+
+  const item = await buildRepoItem(entry, null, async function() {
+    return {
+      stars: 30,
+      forks: 6,
+      lastTag: "v3.0.0",
+      lastUpdate: "2026-01-01T00:00:00Z",
+      isArchived: true
+    };
+  });
+
+  assert.equal(item.isArchived, false);
+});

--- a/src/components/Repos.vue
+++ b/src/components/Repos.vue
@@ -1,44 +1,60 @@
 <template>
-  <v-card>
-    <v-card-title>
-      <span id="title">Repos</span>
-      <v-tooltip bottom>
-        <template v-slot:activator="{ on }">
-          <v-btn dark small color="light-blue" v-on="on" @click="goto">
-            <v-icon>add</v-icon>
-          </v-btn>
-        </template>
-        <span>Add your own awesome-streaming project</span>
-      </v-tooltip>
-      <v-spacer />
-      <v-text-field v-model="search" append-icon="search" label="Search" single-line hide-details></v-text-field>
-    </v-card-title>
-    <v-data-table
-      :headers="headers"
-      :items="items"
-      :sort-by="['lastUpdateSortValue']"
-      :sort-desc="[true]"
-      :items-per-page="100"
-      :search="search"
-      hide-default-footer
-      class="elevation-1"
+  <div>
+    <v-card
+      v-for="section in sections"
+      :key="section.title"
+      :class="{ 'archived-section': section.isArchived }"
     >
-      <template v-slot:body="{ items }">
-        <tbody>
-          <tr v-for="item in items" :key="item.name">
-            <td>
-              <a :href="item.link" target="_blank">{{ item.name }}</a>
-            </td>
-            <td>{{ item.description }}</td>
-            <td>{{ item.stars }}</td>
-            <td>{{ item.forks }}</td>
-            <td>{{ item.lastTag }}</td>
-            <td>{{ item.lastUpdate }}</td>
-          </tr>
-        </tbody>
-      </template>
-    </v-data-table>
-  </v-card>
+      <v-card-title>
+        <span class="section-title">{{ section.title }}</span>
+        <v-chip small outlined>{{ sectionItems(section).length }}</v-chip>
+        <v-tooltip v-if="!section.isArchived" bottom>
+          <template v-slot:activator="{ on }">
+            <v-btn dark small color="light-blue" class="add-project" v-on="on" @click="goto">
+              <v-icon>add</v-icon>
+            </v-btn>
+          </template>
+          <span>Add your own awesome-streaming project</span>
+        </v-tooltip>
+        <v-spacer />
+        <v-text-field
+          v-model="section.search"
+          append-icon="search"
+          :label="'Search ' + section.title.toLowerCase() + ' projects'"
+          single-line
+          hide-details
+        ></v-text-field>
+      </v-card-title>
+      <v-card-subtitle v-if="section.isArchived">
+        Archived projects retain their last known metadata without daily refreshes.
+      </v-card-subtitle>
+      <v-data-table
+        :headers="headers"
+        :items="sectionItems(section)"
+        :sort-by="['lastUpdateSortValue']"
+        :sort-desc="[true]"
+        :items-per-page="100"
+        :search="section.search"
+        hide-default-footer
+        class="elevation-1"
+      >
+        <template v-slot:body="{ items }">
+          <tbody>
+            <tr v-for="item in items" :key="item.name">
+              <td>
+                <a :href="item.link" target="_blank">{{ item.name }}</a>
+              </td>
+              <td>{{ item.description }}</td>
+              <td>{{ item.stars }}</td>
+              <td>{{ item.forks }}</td>
+              <td>{{ item.lastTag }}</td>
+              <td>{{ item.lastUpdate }}</td>
+            </tr>
+          </tbody>
+        </template>
+      </v-data-table>
+    </v-card>
+  </div>
 </template>
 
 <script>
@@ -56,7 +72,10 @@ function normalizeRepos(items) {
 export default {
   data() {
     return {
-      search: "",
+      sections: [
+        { title: "Active", isArchived: false, search: "" },
+        { title: "Archived", isArchived: true, search: "" }
+      ],
       headers: [
         { text: "Name", value: "name" },
         { text: "Description", value: "description", sortable: false },
@@ -71,6 +90,9 @@ export default {
   methods: {
     goto: function() {
       window.open("https://github.com/manuzhang/awesome-streaming", "_blank");
+    },
+    sectionItems: function(section) {
+      return this.items.filter(item => (item.isArchived === true) === section.isArchived);
     }
   }
 };
@@ -93,7 +115,15 @@ a {
   color: #42b983;
 }
 
-#title {
+.section-title {
   margin-right: 10px;
+}
+
+.add-project {
+  margin-left: 10px;
+}
+
+.archived-section {
+  margin-top: 24px;
 }
 </style>

--- a/src/components/Repos.vue
+++ b/src/components/Repos.vue
@@ -40,7 +40,11 @@
       >
         <template v-slot:body="{ items }">
           <tbody>
-            <tr v-for="item in items" :key="item.name">
+            <tr
+              v-for="item in items"
+              :key="item.name"
+              :class="{ 'archived-project': section.isArchived }"
+            >
               <td>
                 <a :href="item.link" target="_blank">{{ item.name }}</a>
               </td>
@@ -125,5 +129,11 @@ a {
 
 .archived-section {
   margin-top: 24px;
+  background-color: #f5f5f5;
+}
+
+.archived-project,
+.archived-project:hover {
+  background-color: #f5f5f5 !important;
 }
 </style>


### PR DESCRIPTION
## Summary

- split the dashboard into separate searchable Active and Archived sections
- give the Archived section and archived project rows a gray background
- treat the upstream README Archived badge as authoritative, including metadata fallback paths
- reuse complete stored metadata for archived projects without daily GitHub API requests
- retry archived release lookups after transient failures while preserving successful empty-release results
- preserve successful repository lookups when GitHub returns a valid null push timestamp
- cache generated metadata between non-PR CI runs so one-time archived enrichment persists
- document the active-only daily enrichment and metadata cache behavior

## Why

Archived projects do not need daily status refreshes. Reusing their last known metadata reduces GitHub API traffic while keeping active project metadata current. Persisting generated metadata makes that optimization effective across scheduled CI runners, while explicit repository and release lookup state distinguishes successful empty values from transient failures.

## Dependency

PR #74 is merged, and this branch is rebased on `master`.

## Validation

- `node --test scripts/sync-repos-metadata.test.js` (8 tests)
- live optimized sync: 68 active repositories refreshed, 5 ambiguous legacy archived repositories enriched, 49 archived repositories reused, 122 total retained, 0 failed archived release lookups
- `node --check scripts/sync-repos-metadata.js`
- `vue-cli-service lint`
- `NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build`
- workflow YAML parse
- browser QA: 68 active and 54 archived projects render; the archived section and rows compute to `rgb(245, 245, 245)`; no console errors
- `git diff --check`
- GitHub Actions CI

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: unreviewed
- Prompt Summary: Split the dashboard into Active and Archived sections, stop daily metadata refreshes for archived repositories, address review feedback including valid null push timestamps, and style archived projects with a gray background.